### PR TITLE
Do not export exception handling primitives

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -26,7 +26,6 @@ dependencies:
   - mtl
   - case-insensitive
   - async
-  - safe-exceptions
 
 library:
   source-dirs: src

--- a/src/StdLib.hs
+++ b/src/StdLib.hs
@@ -190,7 +190,6 @@ import Control.Applicative         as X (Alternative (..), Applicative (..),
                                          liftA2, liftA3, optional, (<**>))
 import Control.Concurrent          as X hiding (throwTo)
 import Control.Concurrent.Async    as Async
-import Control.Exception.Safe      as X hiding (Handler (..))
 import Control.Monad               hiding ((<$!>))
 import Control.Monad.Except        as X (Except, ExceptT, MonadError,
                                          catchError, runExcept, runExceptT,


### PR DESCRIPTION
I prefer to handle this on a case-by-case basis for now.  Specifically,
for Assertible I want the option to control what exception primitives
are in scope.