### PR TITLE
Add .cabal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-stdlib.cabal
 .stack-work

--- a/stdlib.cabal
+++ b/stdlib.cabal
@@ -1,0 +1,46 @@
+cabal-version: 1.12
+
+-- This file has been generated from package.yaml by hpack version 0.34.2.
+--
+-- see: https://github.com/sol/hpack
+
+name:           stdlib
+version:        0.1.0.0
+homepage:       https://github.com/rbros/stdlib#readme
+bug-reports:    https://github.com/rbros/stdlib/issues
+author:         Christopher & Cody Reichert (Reichert Brothers)
+maintainer:     christopher@reichertbrothers.com
+copyright:      2018 Reichert Brothers
+license:        MIT
+license-file:   LICENSE
+build-type:     Simple
+extra-source-files:
+    README.md
+
+source-repository head
+  type: git
+  location: https://github.com/rbros/stdlib
+
+library
+  exposed-modules:
+      StdLib
+  other-modules:
+      Paths_stdlib
+  hs-source-dirs:
+      src
+  default-extensions: NoImplicitPrelude
+  ghc-options: -Wall -fno-warn-unused-do-bind -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  build-depends:
+      async
+    , base >=4.7 && <5
+    , bytestring
+    , case-insensitive
+    , containers
+    , directory
+    , filepath
+    , mtl
+    , process
+    , text
+    , time
+    , transformers
+  default-language: Haskell2010


### PR DESCRIPTION
...so that newer versions of stack do not emit a warning when used as a
dependency...